### PR TITLE
Use https for the live site's import endpoint

### DIFF
--- a/assets/scripts/main.js
+++ b/assets/scripts/main.js
@@ -3,7 +3,11 @@
   var SERVER_NAME = $('meta[name="popit-server"]').attr('content');
 
   function import_endpoint(instance_name) { 
-    return 'http://' + instance_name + '.' + SERVER_NAME + '/api/v0.1/imports'
+    var protocol = 'http';
+    if (SERVER_NAME === 'popit.mysociety.org') {
+      protocol = 'https';
+    }
+    return protocol + '://' + instance_name + '.' + SERVER_NAME + '/api/v0.1/imports'
   }
 
   function popitImport(instanceSlug, popoloJson) {


### PR DESCRIPTION
PopIt sets the cookie in the UI to have a secure flag, which means it
will only be served over https connections. So although the API works
over plain http, the cookies weren't being sent correctly and the API
was returning a 401.

This change hardcodes the live site url, which isn't ideal but it gets
the job done.
